### PR TITLE
Linear blend skinning support.

### DIFF
--- a/src/Text/GLTF/Loader/Gltf.hs
+++ b/src/Text/GLTF/Loader/Gltf.hs
@@ -15,6 +15,7 @@ module Text.GLTF.Loader.Gltf
     Sampler (..),
     SamplerWrap (..),
     Scene (..),
+    Skin (..),
     Texture (..),
     TextureInfo (..),
 
@@ -110,6 +111,7 @@ data Gltf = Gltf
     gltfNodes :: Vector Node,
     gltfSamplers :: Vector Sampler,
     gltfScenes :: Vector Scene,
+    gltfSkins :: Vector Skin,
     gltfTextures :: Vector Texture
   }
   deriving (Eq, Show)
@@ -179,6 +181,8 @@ data Node = Node
     nodeRotation :: Maybe (Quaternion Float),
     -- | The node's non-uniform scale
     nodeScale :: Maybe (V3 Float),
+    -- | The index of the skin if it contains a skinned mesh
+    nodeSkin :: Maybe Int,
     -- | The node's translation along the x, y, and z axes.
     nodeTranslation :: Maybe (V3 Float),
     -- | The weights of the instantiated morph target.
@@ -210,6 +214,16 @@ data Scene = Scene
   }
   deriving (Eq, Show)
 
+data Skin = Skin
+  { -- | The inverse bind matrices of the joints in this skin
+    skinInverseBindMatrices :: Vector (M44 Float),
+    -- | The user-defined name of this object
+    skinName :: Maybe Text,
+    -- | The node indices of the joints used by this skin
+    skinJoints :: Vector Int
+  }
+  deriving (Eq, Show)
+
 -- | A texture and its sampler.
 data Texture = Texture
   { -- | The user-defined name of this object.
@@ -236,7 +250,11 @@ data MeshPrimitive = MeshPrimitive
     -- | A Vector of vertex texture coordinates
     meshPrimitiveTexCoords :: Vector (V2 Float),
     -- | A Vector of vertex colors.
-    meshPrimitiveColors :: Vector (V4 Float)
+    meshPrimitiveColors :: Vector (V4 Float),
+    -- | A Vector of the joints which affect each vertex
+    meshPrimitiveJoints :: Vector (V4 Word16),
+    -- | A Vector of joint weights for each vertex
+    meshPrimitiveWeights :: Vector (V4 Float)
   }
   deriving (Eq, Show)
 

--- a/src/Text/GLTF/Loader/Internal/Decoders.hs
+++ b/src/Text/GLTF/Loader/Internal/Decoders.hs
@@ -6,6 +6,12 @@ module Text.GLTF.Loader.Internal.Decoders
     getNormals,
     getTexCoords,
     getColors,
+    getJoints,
+    getJoints16,
+    getWeights,
+    getWeights8,
+    getWeights16,
+    getInverseBindMatrices,
 
     -- * GLTF Accessor Type decoders
     getScalar,
@@ -53,6 +59,30 @@ getTexCoords = getVec2 getFloat
 -- | Vertex colors binary decoder
 getColors :: Get (Vector (V4 Word16))
 getColors = getVec4 getUnsignedShort
+
+-- | Vertex joints binary decoder, for unsigned bytes
+getJoints :: Get (Vector (V4 Word8))
+getJoints = getVec4 getUnsignedByte
+
+-- | Vertex joints binary decoder, for unsigned shorts
+getJoints16 :: Get (Vector (V4 Word16))
+getJoints16 = getVec4 getUnsignedShort
+
+-- | Vertex joint weights binary decoder, for floats
+getWeights :: Get (Vector (V4 Float))
+getWeights = getVec4 getFloat
+
+-- | Vertex weights binary decoder, for unsigned bytes
+getWeights8 :: Get (Vector (V4 Word8))
+getWeights8 = getVec4 getUnsignedByte
+
+-- | Vertex weights binary decoder, for unsigned shorts
+getWeights16 :: Get (Vector (V4 Word16))
+getWeights16 = getVec4 getUnsignedShort
+
+-- | Inverse bind matrix decoder
+getInverseBindMatrices :: Get (Vector (M44 Float))
+getInverseBindMatrices = getMat4 getFloat
 
 -- | Scalar (simple) type binary decoder
 getScalar :: Get a -> Get (Vector a)


### PR DESCRIPTION
This commit adds a few things:

- The top level skins field, containing decoded inverse bind matrices and  their associated joints.
- Support for up to four joints per vertex for posing skinned meshes.
- De-normalization of normalized integers through the `Normalized` type class.